### PR TITLE
Call with geoSatView() and skip UI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## Downloads GOES (GEOS-16 or GEOS-17 currently) or [Zoom Earth](zoom.earth) satellite data and makes video animation using [R](https://www.r-project.org/).
 
+![NOAA](https://user-images.githubusercontent.com/5241605/93047255-f0ea0680-f610-11ea-92a0-7839acea87a0.gif)
+
 This script performs the following actions:
 - For `NOAA` data:
   - Downloads GOES (GEOS-16 or GEOS-17 currently) satellite data (https://cdn.star.nesdis.noaa.gov/GOES16/ABI/SECTOR/psw/GEOCOLOR/) into `data` folder.
@@ -14,11 +16,40 @@ This script performs the following actions:
 The script requires `ffmpeg` be installed on users systems if
 
 ### Usage
-To run, download `R` (or `RStudio`) then make the working directory in `R` the repository root directory and type the below. Users can choose between NOAA or [zoom.earth](zoom.earth) sources to create the video.
+To run:
+- download `R` (or `RStudio`).
+- either download a zip of the repository or make a new folder and clone with `git clone https://github.com/bahanonu/geoSatView.git`.
+- Make the working directory in `R` the repository root directory and type the below.
+- Alternatively, users can download files to a separate folder by making that folder the active working directory then running `source('path/to/geoSatView.R');geoSatView()`
+- Users can choose between NOAA or [zoom.earth](zoom.earth) sources to create the video. Videos are stored in the `data_noaa` or `data_zoom_earth` sub-directories that are created.
 
 ```R
 source('geoSatView.R')
+geoSatView()
 ```
+
+Users can alternatively call the script without user input by using the available options.
+
+```R
+source('geoSatView.R')
+geoSatView(
+    dataDirList=list(NOAA=file.path(getwd(),'data_noaa/'),zoomEarth=file.path(getwd(),'data_zoom_earth/')),
+    userChoice=c("NOAA","zoomEarth"),
+    createVidFlag=c(2)
+)
+```
+
+__Options__
+```
+dataDirList
+    list(), format: c(NOAA="PATH_TO_NOAA_DATA",zoomEarth="PATH_TO_zoomEarth_DATA")
+userChoice
+    char vector, options: "NOAA", "zoomEarth". Can input both c("NOAA","zoomEarth").
+createVidFlag
+    vector, options: Binary: 1 = create AVI video, 0 = do not create video, 2 = create using ffmpeg system call (fastest)
+```
+
+### Example output
 
 Below is an example output. The script is also a useful reference for those looking to manipulate images in `R` and create videos. The script can also be run from an empty directory, as long as you set that directory as `R`'s working directory.
 

--- a/geoSatView.R
+++ b/geoSatView.R
@@ -3,6 +3,10 @@
 	# started: 2018.11.17
 	# Script to download GOES16 GEOCOLOR satellite data to help visualize the November 2018 or October 2019 California Camp Fire
 	# Will download and make a cropped movie for any GEOCOLOR data.
+# Inputs
+	# dataDirList - list(), format: c(NOAA="PATH_TO_NOAA_DATA",zoomEarth="PATH_TO_zoomEarth_DATA")
+	# userChoice - char vector, options: "NOAA", "zoomEarth". Can input both c("NOAA","zoomEarth").
+	# createVidFlag - vector, options: Binary: 1 = create AVI video, 0 = do not create video, 2 = create using ffmpeg system call (fastest)
 
 # changelog
 	# 2019.10.27 - Updated handling of cropping and resizing to make more automatic
@@ -12,51 +16,108 @@
 	# 2020.08.24 [12:22:03] - Made downloading of the files parallel.
 	# 2020.09.11 [11:26:20] - Added additional crop type and save movie file based on system time. Automatically check for and create sub-directories.
 	# 2020.09.13 [20:20:02] - Make this function call either NOAA or zoomEarth based download with user options to start.
+	# 2020.09.15 [11:50:32] - Wrapped calls to NOAA and Zoom Earth scripts in a function to allow running both in the same run.
+	# 2020.09.15 [18:32:21] - Everything inside a function, call with geoSatView.
 # TODO
 	# Add a GUI so users can pick two crop areas and will automatically do the rest
 	# Potentially convert to EBImage for processing images, could be faster.
 
 
 # =================================================
-# Load necessary packages
-for (i in c(1:2)) {
-	lapply(c("xml2","rvest","imager","magick",'grid',"HelpersMG","suncalc","av","parallel","webshot","svDialogs"),FUN=function(file){if(!require(file,character.only = TRUE)){install.packages(file,dep=TRUE);}})
-}
-
-# Ask user for type of download
-userChoice = dlg_list(c("NOAA","zoomEarth"), multiple = TRUE, title='Select satellite download location')$res
-
-# Ask user
-vidDlgList = c("1 = Save video with R 'av' package","2 = Save video with ffmpeg (faster)")
-createVidFlag = dlg_list(vidDlgList, title=paste0("1 = Save video with R 'av' package","2 = Save video with ffmpeg"), multiple = TRUE)$res
-createVidFlag = which(vidDlgList %in% createVidFlag)
-
-thisFileFolder <- function() {
-	# From https://stackoverflow.com/a/15373917
-	cmdArgs <- commandArgs(trailingOnly = FALSE)
-	needle <- "--file="
-	match <- grep(needle, cmdArgs)
-	if (length(match) > 0) {
-		# Rscript
-		return(dirname(normalizePath(sub(needle, "", cmdArgs[match]))))
-	} else {
-		# 'source'd via R console
-		return(dirname(normalizePath(sys.frames()[[1]]$ofile)))
+subfxnLoadPkgs <- function() {
+	# Load necessary packages and support files
+	for (i in c(1:2)) {
+		lapply(c("xml2","rvest","imager","magick",'grid',"HelpersMG","suncalc","av","parallel","webshot","svDialogs","scriptName"),FUN=function(file){if(!require(file,character.only = TRUE)){install.packages(file,dep=TRUE);}})
 	}
 }
 
-geoSatViewPath = thisFileFolder()
-
-source(file.path(geoSatViewPath,"R","geoSatView_makeVideoList.R"))
-
-if (!length(userChoice)) {
-	cat("You canceled the choice\n")
-}else if(userChoice=="NOAA"){
-	print(paste0('Running geoSatView: ',userChoice))
-	dataDir = 'data_noaa/'
-	source(file.path(geoSatViewPath,"R","geoSatView_noaa.R"))
-}else if(userChoice=="zoomEarth"){
-	print(paste0('Running geoSatView: ',userChoice))
-	dataDir = 'data_zoom_earth/'
-	source(file.path(geoSatViewPath,"R","geoSatView_zoomEarth.R"))
+# =================================================
+# Necessary functions
+thisFileFolder <- function() {
+	# Obtains the full path for a script
+	# From https://stackoverflow.com/a/15373917
+	# cmdArgs <- commandArgs(trailingOnly = FALSE)
+	# needle <- "--file="
+	# match <- grep(needle, cmdArgs)
+	# if (length(match) > 0) {
+	# 	# Rscript
+	# 	return(dirname(normalizePath(sub(needle, "", cmdArgs[match]))))
+	# } else {
+	# 	# 'source'd via R console
+	# 	return(dirname(normalizePath(sys.frames()[[1]]$ofile)))
+	# }
+	# @return full path to this script
+    cmdArgs = commandArgs(trailingOnly = FALSE)
+    needle = "--file="
+    match = grep(needle, cmdArgs)
+    if (length(match) > 0) {
+        # Rscript
+        fileNameH = normalizePath(sub(needle, "", cmdArgs[match]))
+    } else {
+        ls_vars = ls(sys.frames()[[1]])
+        if ("fileName" %in% ls_vars) {
+            # Source'd via RStudio
+            fileNameH = normalizePath(sys.frames()[[1]]$fileName)
+        } else {
+            # Source'd via R console
+            fileNameH = normalizePath(sys.frames()[[1]]$ofile)
+        }
+    }
+    return(dirname(fileNameH))
 }
+subfxnRunAnalysis <- function(usrChoiceRun,createVidFlag,geoSatViewPath,dataDir) {
+	print(sprintf('Running %s analysis.',usrChoiceRun))
+	if(usrChoiceRun=="NOAA"){
+		print(paste0('Running geoSatView: ',usrChoiceRun))
+		geoSatView_noaa(dataDir,createVidFlag)
+		# source(file.path(geoSatViewPath,"R","geoSatView_noaa.R"), local=TRUE)
+		# source(file.path(geoSatViewPath,"R","geoSatView_noaa.R"))
+	}else if(usrChoiceRun=="zoomEarth"){
+		print(paste0('Running geoSatView: ',usrChoiceRun))
+		geoSatView_zoomEarth(dataDir,createVidFlag)
+		# source(file.path(geoSatViewPath,"R","geoSatView_zoomEarth.R"), local=TRUE)
+		# source(file.path(geoSatViewPath,"R","geoSatView_zoomEarth.R"))
+	}
+}
+
+geoSatView <- function(dataDirList=c(),userChoice=c(),createVidFlag=c()){
+	# =================================================
+	# PARAMETERS
+	if(length(dataDirList)==0){
+		dataDirList = list()
+		dataDirList$NOAA = file.path(getwd(),'data_noaa/')
+		dataDirList$zoomEarth = file.path(getwd(),'data_zoom_earth/')
+	}
+
+	if(length(userChoice)==0){
+		# Ask user for type of download
+		downloadList = c("NOAA","zoomEarth")
+		userChoice = dlg_list(downloadList, multiple = TRUE, preselect = downloadList, title = 'Select satellite download location (for text, space between multiple options)')$res
+	}
+
+	if(length(createVidFlag)==0){
+		# Ask user
+		vidDlgList = c("1 = Save video with R 'av' package","2 = Save video with ffmpeg (faster)")
+		createVidFlag = dlg_list(vidDlgList, preselect = vidDlgList[2], title = paste0("1 = Save video with R 'av' package","2 = Save video with ffmpeg"), multiple = TRUE)$res
+		createVidFlag = which(vidDlgList %in% createVidFlag)
+	}
+
+	if (!length(userChoice)) {
+		cat("You canceled the choice\n")
+	}else{
+		for (usrChoiceHere in userChoice) {
+			dataDir =  dataDirList[[usrChoiceHere]]
+			subfxnRunAnalysis(usrChoiceHere,createVidFlag,geoSatViewPath,dataDir)
+		}
+	}
+}
+
+# =================================================
+# MAIN
+# Load helper functions and packages.
+subfxnLoadPkgs()
+# Load necessary files and get path of function
+# geoSatViewPath = thisFileFolder()
+source(file.path(thisFileFolder(),"R","geoSatView_makeVideoList.R"))
+source(file.path(thisFileFolder(),"R","geoSatView_noaa.R"), local=TRUE)
+source(file.path(thisFileFolder(),"R","geoSatView_zoomEarth.R"), local=TRUE)


### PR DESCRIPTION
- Allow NOAA and Zoom Earth runs in the same call.
- Fixes to environment that `geoSatView_zoomEarth.R` and `geoSatView_noaa.R` are called in.
- Wraps everything inside functions, no variables loaded in global environment.
- Call with `geoSatView`.